### PR TITLE
feat(#35): update css-selector-parser to v3.3.0

### DIFF
--- a/lib/css-selector-classes.js
+++ b/lib/css-selector-classes.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const createParser = require('css-selector-parser').createParser;
-const parse = createParser({ syntax: 'progressive' });
-
-/* eslint-disable complexity */
+const parse = createParser({ syntax: 'progressive', strict: false });
 
 /**
- * Recursively visits nodes in a CSS rule tree and applies a function to each rule node.
+ * Recursively visits nodes in a CSS rule tree and applies a function to each rule node item.
+ * (Classes as attributes are ignored.)
  *
  * @param {Object} node - The root node of the CSS rule tree.
  * @param {function} fn - The function to apply to each rule node.
@@ -20,30 +19,18 @@ function visitRules(node, fn) {
 		node.rules.forEach((rule) => visitRules(rule, fn));
 	}
 
-	if (node.nestedRule?.pseudoClasses) {
-		node.nestedRule.pseudoClasses.forEach((pseudo) => visitRules(pseudo.argument, fn));
+	if (node.nestedRule) {
+		visitRules(node.nestedRule, fn);
 	}
 
-	if (node.attributes) {
-		const classAttribute = node.attributes.find((attribute) => attribute.name === 'class');
-		if (classAttribute?.value?.value) {
-			fn({ classNames: [classAttribute.value.value] });
+	node.items?.forEach((item) => {
+		if (item.type === 'ClassName') {
+			fn(item.name);
+		} else if (item.type === 'PseudoClass') {
+			visitRules(item.argument, fn);
 		}
-	}
-
-	if (node.pseudoClasses) {
-		node.pseudoClasses.forEach((pseudo) => {
-			if (pseudo.argument?.rules) {
-				pseudo.argument.rules.forEach((rule) => visitRules(rule, fn));
-			}
-		});
-	}
-
-	if (node.type === 'Rule') {
-		fn(node);
-	}
+	});
 }
-/* eslint-enable complexity */
 
 /**
  * Return all the classes in a CSS selector.
@@ -52,13 +39,11 @@ function visitRules(node, fn) {
  * @returns {string[]} An array of every class present in the CSS selector
  */
 function getCssSelectorClasses(selector) {
-	let list = [];
+	const list = [];
 	const ast = parse(selector);
-	visitRules(ast, (ruleSet) => {
-		if (ruleSet.classNames) {
-			list = list.concat(ruleSet.classNames);
-		}
-	});
+
+	visitRules(ast, (className) => list.push(className));
+
 	return Array.from(new Set(list));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
-        "css-selector-parser": "2.3.2",
+        "css-selector-parser": "3.3.0",
         "postcss-resolve-nested-selector": "0.1.6"
       },
       "devDependencies": {
@@ -3365,9 +3365,9 @@
       }
     },
     "node_modules/css-selector-parser": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-2.3.2.tgz",
-      "integrity": "sha512-JjnG6/pdLJh3iqipq7kteNVtbIczsU2A1cNxb+VAiniSuNmrB/NI3us4rSCfArvlwRXYly+jZhUUfEoInSH9Qg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "Merkle Inc.",
   "license": "MIT",
   "dependencies": {
-    "css-selector-parser": "2.3.2",
+    "css-selector-parser": "3.3.0",
     "postcss-resolve-nested-selector": "0.1.6"
   },
   "peerDependencies": {

--- a/test/default.test.js
+++ b/test/default.test.js
@@ -87,10 +87,6 @@ testRule({
 			message: `Expected class name "z-block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (${ruleName})`,
 		},
 		{
-			code: '.0-block {}',
-			message: `Expected class name "0-block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (${ruleName})`,
-		},
-		{
 			code: '.-block {}',
 			message: `Expected class name "-block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (${ruleName})`,
 		},


### PR DESCRIPTION
## Purpose

Solve: https://github.com/merkle-open/stylelint-bem/issues/35

## Changes

* Update `css-selector-parser` from `2.3.2` to `3.3.0` (latest version)
* Refactor `getCssSelectorClasses` to align selector parsing logic with updated tree structure
* Remove `.0-block {}` test case, as class names cannot start with a digit ([w3.org](https://www.w3.org/TR/CSS2/syndata.html#characters))